### PR TITLE
feat: category read & delete api implement

### DIFF
--- a/ministory/src/main/java/com/example/ministory/controller/CategoryController.java
+++ b/ministory/src/main/java/com/example/ministory/controller/CategoryController.java
@@ -28,7 +28,8 @@ public class CategoryController {
     // TODO: 유저의 카테고리를 전부 받아서 리스팅하는 함수
     @GetMapping("")
     public String getCategoryList(Model model, Long userId) {
-        // User user = /* Use userId to retrieve the user */;
+        List<Category> categories = categoryService.findUserCategory(1L);
+        model.addAttribute("categories", categories);
         return "category/categoryList";
     }
 
@@ -38,7 +39,7 @@ public class CategoryController {
         categoryDto.setTitle("test");
         // TODO: 1번 유저가 생성한 카테고리로 우선 분류
         categoryService.saveCategoryOnUser(categoryDto, 1L);
-        return "category/categoryList";
+        return "redirect:category";
     }
 
     /*
@@ -51,13 +52,9 @@ public class CategoryController {
     }
     */
 
-    // TODO: 유저의 카테고리와 하위 게시글을 삭제하는 함수
-
-    /*
-    @GetMapping("/")
-    public String getSignUp(CategoryDto categoryDto, Long userId) {
-        return "category/categoryList";
+    @PostMapping("/delete")
+    public String deleteCategory(Long categoryId) {
+        categoryService.deleteCategory(categoryId);
+        return "redirect:/api/category";
     }
-    */
-
 }

--- a/ministory/src/main/java/com/example/ministory/controller/UserController.java
+++ b/ministory/src/main/java/com/example/ministory/controller/UserController.java
@@ -35,7 +35,7 @@ public class UserController {
             return "userCreateForm";
         }
         userService.saveUser(userDto);
-        return "redirect:/";
+        return "redirect:";
     }
 
     @GetMapping("/list")

--- a/ministory/src/main/java/com/example/ministory/service/CategoryService.java
+++ b/ministory/src/main/java/com/example/ministory/service/CategoryService.java
@@ -4,11 +4,13 @@ import com.example.ministory.dto.CategoryDto;
 import com.example.ministory.entity.User;
 import com.example.ministory.entity.Category;
 
+import com.example.ministory.exception.NotFoundException;
 import com.example.ministory.repository.UserRepository;
 import com.example.ministory.repository.CategoryRepository;
 
 
 import lombok.AllArgsConstructor;
+import org.aspectj.weaver.ast.Not;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -25,13 +27,13 @@ public class CategoryService {
 
     @Transactional
     public List<Category> findUserCategory(Long userId) {
-        User user = userRepository.findById(userId).orElseThrow(() -> new RuntimeException());
+        User user = userRepository.findById(userId).orElseThrow(() -> new NotFoundException("해당하는 User가 없습니다."));
         return categoryRepository.findCategoriesByUser(user);
     }
 
     @Transactional
     public void saveCategoryOnUser(CategoryDto categoryDto, Long userId) {
-        User user = userRepository.findById(userId).orElseThrow(()-> new RuntimeException());
+        User user = userRepository.findById(userId).orElseThrow(()-> new NotFoundException("해당하는 User가 없습니다."));
         System.out.println(categoryDto.getTitle());
         Category category = categoryDto.toEntity(user);
 
@@ -40,7 +42,7 @@ public class CategoryService {
 
     @Transactional
     public void updateCategory(Long categoryId, String title) {
-        Category category = categoryRepository.findById(categoryId).orElseThrow(() -> new RuntimeException());
+        Category category = categoryRepository.findById(categoryId).orElseThrow(() -> new NotFoundException("해당하는 Category가 없습니다."));
         category.setTitle(title);
     }
 

--- a/ministory/src/main/resources/templates/category/categoryList.html
+++ b/ministory/src/main/resources/templates/category/categoryList.html
@@ -17,5 +17,28 @@
         </div>
         <button type="submit" class="btn btn-primary">등록하기</button>
     </form>
+
+    <div>
+        <table class="table">
+            <thead class="table">
+            <tr>
+                <th>카테고리명</th>
+                <th>삭제</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr th:each="category : ${categories}">
+                <td th:text="${category.title}"></td>
+                <td>
+                    <form th:action="@{/api/category/delete}" th:method="POST">
+                        <input type="hidden" name="categoryId" th:value="${category.categoryId}" />
+                        <button type="submit" name="_method" class="btn btn-danger" value="DELETE">삭제하기</button>
+                    </form>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+
 </div> <!-- /container -->
 </html>


### PR DESCRIPTION
회원가입 이후 /api/category 주소에서 카테고리를 입력하면 test라는 더미 카테고리가 올라갑니다.
조회되는 카테고리들은 입력창 아래 테이블에 표시되며, 우측의 삭제하기 버튼을 누르면 삭제됩니다.

카테고리 컨트롤러 API에 입력받을 유저 데이터가 없는 경우 에러메시지 출력하도록 Exception을 추가하였습니다.